### PR TITLE
Call to_string/1 on location.line to appease Datadog agent

### DIFF
--- a/lib/opencensus/absinthe/middleware.ex
+++ b/lib/opencensus/absinthe/middleware.ex
@@ -45,7 +45,7 @@ defmodule Opencensus.Absinthe.Middleware do
       field_type: type,
       field_module: module |> delixir(),
       field_file: location.file,
-      field_line: location.line
+      field_line: to_string(location.line)
     ]
   end
 


### PR DESCRIPTION
Hello and thanks for the lib! 

I am trying to use it with the [Datadog exporter](https://github.com/opencensus-beam/opencensus_datadog), but getting the following error:
`[error] DD: Unable to send spans, DD reported an error: 400: 'json: cannot unmarshal number into Go struct field Span.meta of type string\n'`

It appears that the datadog agent expects all of the metadata field values to be strings but the `field_line` value is currently an int.  
