### PR TITLE
Fix compile time Absinthe.Plug race condition

### DIFF
--- a/lib/opencensus/absinthe/plug.ex
+++ b/lib/opencensus/absinthe/plug.ex
@@ -12,24 +12,19 @@ defmodule Opencensus.Absinthe.Plug do
     schema: MyApp.Schema,
     pipeline: {Opencensus.Absinthe.Plug, :traced_pipeline}
   ```
-
-  **WARNING:** `traced_pipeline/2` will be present _only_ if `Absinthe.Plug` is loaded.
-  Don't forget your `absinthe_plug` dependency in `mix.exs`!
   """
 
-  if Code.ensure_loaded?(Absinthe.Plug) do
-    @doc """
-    Return the default pipeline with tracing phases.
+  @doc """
+  Return the default pipeline with tracing phases.
 
-    See also:
+  See also:
 
-    * `Absinthe.Pipeline.for_document/2`.
-    * `Absinthe.Plug.default_pipeline/1`.
-    """
-    def traced_pipeline(config, pipeline_opts \\ []) do
-      config
-      |> Absinthe.Plug.default_pipeline(pipeline_opts)
-      |> Opencensus.Absinthe.add_phases()
-    end
+  * `Absinthe.Pipeline.for_document/2`.
+  * `Absinthe.Plug.default_pipeline/1`.
+  """
+  def traced_pipeline(config, pipeline_opts \\ []) do
+    config
+    |> Absinthe.Plug.default_pipeline(pipeline_opts)
+    |> Opencensus.Absinthe.add_phases()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Opencensus.Absinthe.MixProject do
 
   defp deps() do
     [
-      {:absinthe_plug, "~> 1.4.0", only: :dev, runtime: false},
+      {:absinthe_plug, "~> 1.4.0", only: [:dev, :test], runtime: false},
       {:absinthe, "~> 1.4.0"},
       {:credo, "~> 0.10.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false},


### PR DESCRIPTION
The `if Code.ensure_loaded?(Absinthe.Plug)` line removed by this PR is evaluated at compile time, not run time. This means if `absinthe_plug` is compiled later than this library the `traced_pipeline`
method will not be present.

It could work locally due to `absinthe_plug` being added and compiled before this module. However if there is a different compilation order in e.g. a CI build the function is not added causing an `UndefinedFunctionError` failure.