### PR TITLE
Make absinthe_plug an optional runtime dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Opencensus.Absinthe.MixProject do
 
   defp deps() do
     [
-      {:absinthe_plug, "~> 1.4.0", only: :dev, runtime: false},
+      {:absinthe_plug, "~> 1.4.0", optional: true},
       {:absinthe, "~> 1.4.0"},
       {:credo, "~> 0.10.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false},


### PR DESCRIPTION
Per:
https://github.com/opencensus-beam/opencensus_absinthe/pull/13/files#r290670529

This resolves a race condition at compile-time. See upstream PR here:
https://github.com/opencensus-beam/opencensus_absinthe/pull/13

See previous discussion here: https://github.com/opencensus-beam/opencensus_absinthe/pull/14